### PR TITLE
Support quickly upload Avatar via Enter Key

### DIFF
--- a/web/src/components/AvatarPicker.tsx
+++ b/web/src/components/AvatarPicker.tsx
@@ -40,6 +40,9 @@ export const AvatarPicker: React.FC<AvatarPickerProps> = React.memo((props) => {
             const key = openModal(
               <ModalAvatarCropper
                 imageUrl={reader.result.toString()}
+                onCancel={() => {
+                  closeModal(key);
+                }}
                 onConfirm={(croppedImageBlobUrl) => {
                   closeModal(key);
                   updateAvatar(croppedImageBlobUrl);

--- a/web/src/components/modals/AvatarCropper.tsx
+++ b/web/src/components/modals/AvatarCropper.tsx
@@ -2,9 +2,11 @@ import Cropper from 'react-easy-crop';
 import type { Area } from 'react-easy-crop/types';
 import _isNil from 'lodash/isNil';
 import { showToasts, t } from 'tailchat-shared';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Button } from 'antd';
 import { ModalWrapper } from '../Modal';
+import { useGlobalKeyDown } from '@/hooks/useGlobalKeyDown';
+import { isEnterHotkey } from '@/utils/hot-key';
 
 const createImage = (url: string): Promise<HTMLImageElement> =>
   new Promise((resolve, reject) => {
@@ -104,6 +106,12 @@ export const ModalAvatarCropper: React.FC<{
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [area, setArea] = useState<Area>({ width: 0, height: 0, x: 0, y: 0 });
+
+  useGlobalKeyDown((e) => {
+    if (isEnterHotkey(e)) {
+      handleConfirm();
+    }
+  });
 
   const handleConfirm = async () => {
     const blobUrl = await getCroppedImg(

--- a/web/src/components/modals/AvatarCropper.tsx
+++ b/web/src/components/modals/AvatarCropper.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import { Button } from 'antd';
 import { ModalWrapper } from '../Modal';
 import { useGlobalKeyDown } from '@/hooks/useGlobalKeyDown';
-import { isEnterHotkey } from '@/utils/hot-key';
+import { isEnterHotkey, isEscHotkey } from '@/utils/hot-key';
 
 const createImage = (url: string): Promise<HTMLImageElement> =>
   new Promise((resolve, reject) => {
@@ -102,6 +102,7 @@ function getCroppedImg(
 export const ModalAvatarCropper: React.FC<{
   imageUrl: string;
   onConfirm: (croppedImageBlobUrl: string) => void;
+  onCancel: () => void;
 }> = React.memo((props) => {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
@@ -110,6 +111,9 @@ export const ModalAvatarCropper: React.FC<{
   useGlobalKeyDown((e) => {
     if (isEnterHotkey(e)) {
       handleConfirm();
+    } else if (isEscHotkey(e)) {
+      e.stopPropagation();
+      props.onCancel();
     }
   });
 


### PR DESCRIPTION
#10 was solved now.

And I found ESC keypress will close Setting backdrop but level AvatarCropper Modal opened alone. So I add a cancel callback prop to the AvatarCropper component.

By the way. I try to prevent SettingBackdrop's close via e.stopPropagation() in https://github.com/msgbyte/tailchat/compare/master...shikelong:master#diff-c75f55ea1722811561c4e772f49ca4cc0a9e3e14b3a8ce2fa80b0c80c10260dfR115

But I failed, I don't know the reason. --  Seem Settingbackdrop's ESC closing not relay on useGlobalKeyDown hook?
