### PR TITLE
用resolve替代join || Use resolve instead of join

### DIFF
--- a/apps/cli/src/commands/docker/init.ts
+++ b/apps/cli/src/commands/docker/init.ts
@@ -22,7 +22,7 @@ const initCompleted = (dir: string) =>
 Congratulations, you have successfully completed the configuration initialization, your configuration file is ready, and you are one step away from a successful deployment!
 
 Your tailchat configuration files are stored in: ${chalk.underline(
-    path.join(process.cwd(), dir)
+    path.resolve(process.cwd(), dir)
   )}
 
 Run the following command to complete the image download and start:


### PR DESCRIPTION
path.join无法处理绝对地址
![image](https://github.com/msgbyte/tailchat/assets/61458340/73416ba6-73de-4fe4-91ec-9858b0104ce4)

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
path.join cannot handle absolute addresses
![image](https://github.com/msgbyte/tailchat/assets/61458340/73416ba6-73de-4fe4-91ec-9858b0104ce4)
