### PR TITLE
优化props.src判断 || Optimize props.src judgment

### DIFF
--- a/client/packages/design/components/AvatarWithPreview/index.tsx
+++ b/client/packages/design/components/AvatarWithPreview/index.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import { Avatar, AvatarProps } from '../Avatar';
 import { Image, imageUrlParser } from '../Image';
+import { isValidStr } from '../utils';
 
 export const AvatarWithPreview: React.FC<AvatarProps> = React.memo((props) => {
   const [visible, setVisible] = useState(false);
 
-  const hasImage = typeof props.src === 'string';
+  const hasImage = isValidStr(props.src);
 
   return (
     <>


### PR DESCRIPTION
有些时候会出现有avatar字段但为""的情况

Bot头像能点开，但没预览图
![image](https://github.com/msgbyte/tailchat/assets/61458340/37099c14-d20a-49a2-95e0-d688a55b72ef)
![image](https://github.com/msgbyte/tailchat/assets/61458340/712764ad-980b-42de-9732-02d913c2e65e)

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Sometimes there will be a situation where the avatar field is ""

The Bot avatar can be clicked, but there is no preview image
![image](https://github.com/msgbyte/tailchat/assets/61458340/37099c14-d20a-49a2-95e0-d688a55b72ef)
![image](https://github.com/msgbyte/tailchat/assets/61458340/712764ad-980b-42de-9732-02d913c2e65e)
