### PR TITLE
add getMessage api

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -830,6 +830,24 @@
         }
       }
     },
+    "/chat.message/getMessage": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messageId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chat.message/deleteMessage": {
       "post": {
         "requestBody": {

--- a/server/services/core/chat/message.service.ts
+++ b/server/services/core/chat/message.service.ts
@@ -59,6 +59,11 @@ class MessageService extends TcService {
         messageId: 'string',
       },
     });
+    this.registerAction('getMessage', this.getMessage, {
+      params: {
+        messageId: 'string',
+      },
+    });
     this.registerAction('deleteMessage', this.deleteMessage, {
       params: {
         messageId: 'string',
@@ -330,6 +335,32 @@ class MessageService extends TcService {
     });
 
     return json;
+  }
+
+  /**
+   * 获取消息
+   */
+  async getMessage(ctx: TcContext<{ messageId: string }>) {
+    const { messageId } = ctx.params;
+    const { t, userId } = ctx.meta;
+    const message = await this.adapter.model.findById(messageId);
+    const converseId = String(message.converseId);
+    const groupId = message.groupId;
+    // 鉴权
+    if (!groupId) {
+      // 私人会话
+      const converseInfo = await call(ctx).getConverseInfo(converseId);
+      if (!converseInfo.members.map((m) => String(m)).includes(userId)) {
+        throw new DataNotFoundError(t('该消息未找到'));
+      }
+    } else {
+      // 群组会话
+      const groupInfo = await call(ctx).getGroupInfo(String(groupId));
+      if (!groupInfo.members.map((m) => m.userId).includes(userId)) {
+        throw new DataNotFoundError(t('该消息未找到'));
+      }
+    }
+    return message;
   }
 
   /**

--- a/server/services/core/chat/message.service.ts
+++ b/server/services/core/chat/message.service.ts
@@ -344,6 +344,9 @@ class MessageService extends TcService {
     const { messageId } = ctx.params;
     const { t, userId } = ctx.meta;
     const message = await this.adapter.model.findById(messageId);
+    if (!message) {
+      throw new DataNotFoundError(t('该消息未找到'));
+    }
     const converseId = String(message.converseId);
     const groupId = message.groupId;
     // 鉴权
@@ -351,13 +354,13 @@ class MessageService extends TcService {
       // 私人会话
       const converseInfo = await call(ctx).getConverseInfo(converseId);
       if (!converseInfo.members.map((m) => String(m)).includes(userId)) {
-        throw new DataNotFoundError(t('该消息未找到'));
+        throw new NoPermissionError(t('没有当前会话权限'));
       }
     } else {
       // 群组会话
       const groupInfo = await call(ctx).getGroupInfo(String(groupId));
       if (!groupInfo.members.map((m) => m.userId).includes(userId)) {
-        throw new DataNotFoundError(t('该消息未找到'));
+        throw new NoPermissionError(t('没有当前会话权限'));
       }
     }
     return message;


### PR DESCRIPTION
使用场景->用机器人的时候监听贴表情的事件, 如果有getMessage会方便很多
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Usage scenario -> When using a robot, listen to the event of emoticon posting. It would be much more convenient if there is getMessage
