### PR TITLE
docs: add ClawCloud Run button

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Visit the official website to learn more: [https://tailchat.msgbyte.com/](https:
 
 [![Deploy on Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Dtailchat)
 
+### Deploy on ClawCloud Run
+
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=R8D5TGYVHBNJ&openapp=system-fastdeploy%3FtemplateName%3Dtailchat)
+
 ## Communication
 
 If you are interested in `Tailchat`, welcome to join `Tailchat`'s seed user exchange group, your feedback can help `Tailchat` grow better

--- a/README.zh.md
+++ b/README.zh.md
@@ -71,6 +71,10 @@
 
 [![Deploy on Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Dtailchat)
 
+### 使用 ClawCloud Run 部署
+
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?referralCode=R8D5TGYVHBNJ&openapp=system-fastdeploy%3FtemplateName%3Dtailchat)
+
 ### 使用宝塔快速部署
 
 [使用宝塔部署一键部署](https://tailchat.msgbyte.com/zh-Hans/docs/deployment/other-way/bt)


### PR DESCRIPTION
docs: add ClawCloud Run button

---
We are **ClawCloud Run** — a cloud-native deployment platform where users can deploy your application with one click. The referral code in the deployment link is only for anonymous traffic analytics to help us improve our platform. If you’d like to use your own code, simply sign up on ClawCloud Run and replace it in seconds.